### PR TITLE
Tui cli abstraction

### DIFF
--- a/opencode/README.md
+++ b/opencode/README.md
@@ -1,0 +1,17 @@
+# OpenCode TUI CLI extraction
+
+This directory contains an extracted, minimal TUI CLI command-line layer based on
+the opencode dev branch. The goal is to isolate the CLI entry points and their
+worker/RPC bridge without pulling in the full application.
+
+Source references (dev branch):
+- packages/opencode/src/cli/cmd/tui/thread.ts
+- packages/opencode/src/cli/cmd/tui/attach.ts
+- packages/opencode/src/cli/cmd/tui/worker.ts
+- packages/opencode/src/cli/network.ts
+- packages/opencode/src/util/rpc.ts
+
+Intentionally omitted:
+- TUI UI components, routes, and context providers
+- Server/config/project subsystems
+- Non-TUI CLI commands

--- a/opencode/tui-cli/src/commands/attach.ts
+++ b/opencode/tui-cli/src/commands/attach.ts
@@ -1,0 +1,37 @@
+import { cmd } from "../core/cmd"
+import type { AttachArgs, TuiRunner } from "../core/types"
+
+export type AttachCommandDeps = {
+  tui: TuiRunner
+}
+
+export function createAttachCommand(deps: AttachCommandDeps) {
+  return cmd<AttachArgs>({
+    command: "attach <url>",
+    describe: "attach to a running opencode server",
+    builder: (yargs) =>
+      yargs
+        .positional("url", {
+          type: "string",
+          describe: "http://localhost:4096",
+          demandOption: true,
+        })
+        .option("dir", {
+          type: "string",
+          description: "directory to run in",
+        })
+        .option("session", {
+          alias: ["s"],
+          type: "string",
+          describe: "session id to continue",
+        }),
+    handler: async (args) => {
+      if (args.dir) process.chdir(args.dir)
+      await deps.tui({
+        url: args.url,
+        args: { sessionID: args.session },
+        directory: args.dir ? process.cwd() : undefined,
+      })
+    },
+  })
+}

--- a/opencode/tui-cli/src/commands/thread.ts
+++ b/opencode/tui-cli/src/commands/thread.ts
@@ -1,0 +1,220 @@
+import path from "path"
+import { access } from "fs/promises"
+import { cmd } from "../core/cmd"
+import { Rpc } from "../core/rpc"
+import { iife } from "../core/iife"
+import { Log } from "../core/log"
+import { UI } from "../core/ui"
+import { resolveNetworkOptions, withNetworkOptions } from "../core/network"
+import type {
+  EventSource,
+  Logger,
+  NetworkOptions,
+  ResolvedNetworkOptions,
+  RpcClient,
+  TuiRunner,
+  TuiThreadArgs,
+  Ui,
+  WorkerLike,
+  WorkerRpc,
+} from "../core/types"
+
+declare global {
+  const OPENCODE_WORKER_PATH: string | undefined
+}
+
+type ThreadDeps = {
+  tui: TuiRunner
+  log?: Logger
+  ui?: Ui
+  withNetworkOptions?: <T>(yargs: any) => any
+  resolveNetworkOptions?: (
+    args: NetworkOptions,
+    config?: Record<string, unknown>,
+    argv?: string[],
+  ) => Promise<ResolvedNetworkOptions>
+  createWorker?: (path: string | URL, options: { env: Record<string, string> }) => WorkerLike
+  fileExists?: (path: URL) => Promise<boolean>
+}
+
+type RpcClientInstance = RpcClient<WorkerRpc>
+
+function createWorkerFetch(client: RpcClientInstance): typeof fetch {
+  const fn = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const request = new Request(input, init)
+    const body = request.body ? await request.text() : undefined
+    const result = await client.call("fetch", {
+      url: request.url,
+      method: request.method,
+      headers: Object.fromEntries(request.headers.entries()),
+      body,
+    })
+    return new Response(result.body, {
+      status: result.status,
+      headers: result.headers,
+    })
+  }
+  return fn as typeof fetch
+}
+
+function createEventSource(client: RpcClientInstance): EventSource {
+  return {
+    on: (handler) => client.on("event", handler),
+  }
+}
+
+async function readStdinText(): Promise<string | undefined> {
+  if (process.stdin.isTTY) return undefined
+  return new Promise((resolve, reject) => {
+    let data = ""
+    process.stdin.setEncoding("utf8")
+    process.stdin.on("data", (chunk) => {
+      data += chunk
+    })
+    process.stdin.on("end", () => resolve(data))
+    process.stdin.on("error", reject)
+  })
+}
+
+async function defaultFileExists(path: URL): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function defaultWorkerFactory(path: string | URL, options: { env: Record<string, string> }): WorkerLike {
+  const WorkerCtor = (globalThis as any).Worker
+  return new WorkerCtor(path, options)
+}
+
+export function createTuiThreadCommand(deps: ThreadDeps) {
+  const log = deps.log ?? Log.Default
+  const ui = deps.ui ?? UI
+  const withNetwork = deps.withNetworkOptions ?? withNetworkOptions
+  const resolveNetwork = deps.resolveNetworkOptions ?? resolveNetworkOptions
+  const createWorker = deps.createWorker ?? defaultWorkerFactory
+  const fileExists = deps.fileExists ?? defaultFileExists
+
+  return cmd<TuiThreadArgs>({
+    command: "$0 [project]",
+    describe: "start opencode tui",
+    builder: (yargs) =>
+      withNetwork(yargs)
+        .positional("project", {
+          type: "string",
+          describe: "path to start opencode in",
+        })
+        .option("model", {
+          type: "string",
+          alias: ["m"],
+          describe: "model to use in the format of provider/model",
+        })
+        .option("continue", {
+          alias: ["c"],
+          describe: "continue the last session",
+          type: "boolean",
+        })
+        .option("session", {
+          alias: ["s"],
+          type: "string",
+          describe: "session id to continue",
+        })
+        .option("prompt", {
+          type: "string",
+          describe: "prompt to use",
+        })
+        .option("agent", {
+          type: "string",
+          describe: "agent to use",
+        }),
+    handler: async (args) => {
+      const baseCwd = process.env.PWD ?? process.cwd()
+      const cwd = args.project ? path.resolve(baseCwd, args.project) : process.cwd()
+      const localWorker = new URL("./worker.ts", import.meta.url)
+      const distWorker = new URL("./worker.js", import.meta.url)
+      const workerPath = await iife(async () => {
+        if (typeof OPENCODE_WORKER_PATH !== "undefined") return OPENCODE_WORKER_PATH
+        if (await fileExists(distWorker)) return distWorker
+        return localWorker
+      })
+      try {
+        process.chdir(cwd)
+      } catch {
+        ui.error("Failed to change directory to " + cwd)
+        return
+      }
+
+      const worker = createWorker(workerPath, {
+        env: Object.fromEntries(
+          Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+        ),
+      })
+      worker.onerror = (e) => {
+        log.error(e)
+      }
+      const client = Rpc.client<WorkerRpc>(worker)
+      process.on("uncaughtException", (e) => {
+        log.error(e)
+      })
+      process.on("unhandledRejection", (e) => {
+        log.error(e)
+      })
+      process.on("SIGUSR2", async () => {
+        await client.call("reload", undefined)
+      })
+
+      const prompt = await iife(async () => {
+        const piped = await readStdinText()
+        if (!args.prompt) return piped
+        return piped ? piped + "\n" + args.prompt : args.prompt
+      })
+
+      const networkOpts = await resolveNetwork(args)
+      const shouldStartServer =
+        process.argv.includes("--port") ||
+        process.argv.includes("--hostname") ||
+        process.argv.includes("--mdns") ||
+        networkOpts.mdns ||
+        networkOpts.port !== 0 ||
+        networkOpts.hostname !== "127.0.0.1"
+
+      let url: string
+      let customFetch: typeof fetch | undefined
+      let events: EventSource | undefined
+
+      if (shouldStartServer) {
+        const server = await client.call("server", networkOpts)
+        url = server.url
+      } else {
+        url = "http://opencode.internal"
+        customFetch = createWorkerFetch(client)
+        events = createEventSource(client)
+      }
+
+      const tuiPromise = deps.tui({
+        url,
+        fetch: customFetch,
+        events,
+        args: {
+          continue: args.continue,
+          sessionID: args.session,
+          agent: args.agent,
+          model: args.model,
+          prompt,
+        },
+        onExit: async () => {
+          await client.call("shutdown", undefined)
+        },
+      })
+
+      setTimeout(() => {
+        client.call("checkUpgrade", { directory: cwd }).catch(() => {})
+      }, 1000)
+
+      await tuiPromise
+    },
+  })
+}

--- a/opencode/tui-cli/src/core/cmd.ts
+++ b/opencode/tui-cli/src/core/cmd.ts
@@ -1,0 +1,18 @@
+export type CommandBuilder = {
+  positional: (name: string, options: Record<string, unknown>) => CommandBuilder
+  option: (name: string, options: Record<string, unknown>) => CommandBuilder
+  options: (options: Record<string, unknown>) => CommandBuilder
+}
+
+type WithDoubleDash<T> = T & { "--"?: string[] }
+
+export type CommandModule<TArgs> = {
+  command: string
+  describe: string
+  builder?: (yargs: CommandBuilder) => CommandBuilder
+  handler: (args: TArgs) => Promise<void> | void
+}
+
+export function cmd<TArgs>(input: CommandModule<WithDoubleDash<TArgs>>) {
+  return input
+}

--- a/opencode/tui-cli/src/core/iife.ts
+++ b/opencode/tui-cli/src/core/iife.ts
@@ -1,0 +1,3 @@
+export function iife<T>(fn: () => T) {
+  return fn()
+}

--- a/opencode/tui-cli/src/core/log.ts
+++ b/opencode/tui-cli/src/core/log.ts
@@ -1,0 +1,11 @@
+export const Log = {
+  Default: {
+    error: (message: unknown, extra?: Record<string, unknown>) => {
+      if (extra) {
+        console.error(message, extra)
+        return
+      }
+      console.error(message)
+    },
+  },
+}

--- a/opencode/tui-cli/src/core/network.ts
+++ b/opencode/tui-cli/src/core/network.ts
@@ -1,0 +1,56 @@
+import type { CommandBuilder } from "./cmd"
+import type { NetworkOptions, ResolvedNetworkOptions } from "./types"
+
+const options = {
+  port: {
+    type: "number" as const,
+    describe: "port to listen on",
+    default: 0,
+  },
+  hostname: {
+    type: "string" as const,
+    describe: "hostname to listen on",
+    default: "127.0.0.1",
+  },
+  mdns: {
+    type: "boolean" as const,
+    describe: "enable mDNS service discovery (defaults hostname to 0.0.0.0)",
+    default: false,
+  },
+  cors: {
+    type: "string" as const,
+    array: true,
+    describe: "additional domains to allow for CORS",
+    default: [] as string[],
+  },
+}
+
+export type NetworkConfig = Partial<NetworkOptions>
+
+export function withNetworkOptions<T>(yargs: CommandBuilder): CommandBuilder {
+  return yargs.options(options)
+}
+
+export async function resolveNetworkOptions(
+  args: NetworkOptions,
+  config: NetworkConfig = {},
+  argv: string[] = process.argv,
+): Promise<ResolvedNetworkOptions> {
+  const portExplicitlySet = argv.includes("--port")
+  const hostnameExplicitlySet = argv.includes("--hostname")
+  const mdnsExplicitlySet = argv.includes("--mdns")
+  const corsExplicitlySet = argv.includes("--cors")
+
+  const mdns = mdnsExplicitlySet ? args.mdns : config.mdns ?? args.mdns
+  const port = portExplicitlySet ? args.port : config.port ?? args.port
+  const hostname = hostnameExplicitlySet
+    ? args.hostname
+    : mdns && !config.hostname
+      ? "0.0.0.0"
+      : config.hostname ?? args.hostname
+  const configCors = config.cors ?? []
+  const argsCors = Array.isArray(args.cors) ? args.cors : args.cors ? [args.cors] : []
+  const cors = corsExplicitlySet ? argsCors : [...configCors, ...argsCors]
+
+  return { hostname, port, mdns, cors }
+}

--- a/opencode/tui-cli/src/core/rpc.ts
+++ b/opencode/tui-cli/src/core/rpc.ts
@@ -1,0 +1,66 @@
+export namespace Rpc {
+  type Definition = {
+    [method: string]: (input: any) => any
+  }
+
+  export function listen(rpc: Definition) {
+    onmessage = async (evt) => {
+      const parsed = JSON.parse(evt.data)
+      if (parsed.type === "rpc.request") {
+        const result = await rpc[parsed.method](parsed.input)
+        postMessage(JSON.stringify({ type: "rpc.result", result, id: parsed.id }))
+      }
+    }
+  }
+
+  export function emit(event: string, data: unknown) {
+    postMessage(JSON.stringify({ type: "rpc.event", event, data }))
+  }
+
+  export function client<T extends Definition>(target: {
+    postMessage: (data: string) => void | null
+    onmessage: ((ev: MessageEvent<any>) => any) | null
+  }) {
+    const pending = new Map<number, (result: any) => void>()
+    const listeners = new Map<string, Set<(data: any) => void>>()
+    let id = 0
+    target.onmessage = async (evt) => {
+      const parsed = JSON.parse(evt.data)
+      if (parsed.type === "rpc.result") {
+        const resolve = pending.get(parsed.id)
+        if (resolve) {
+          resolve(parsed.result)
+          pending.delete(parsed.id)
+        }
+      }
+      if (parsed.type === "rpc.event") {
+        const handlers = listeners.get(parsed.event)
+        if (handlers) {
+          for (const handler of handlers) {
+            handler(parsed.data)
+          }
+        }
+      }
+    }
+    return {
+      call<Method extends keyof T>(method: Method, input: Parameters<T[Method]>[0]): Promise<ReturnType<T[Method]>> {
+        const requestId = id++
+        return new Promise((resolve) => {
+          pending.set(requestId, resolve)
+          target.postMessage(JSON.stringify({ type: "rpc.request", method, input, id: requestId }))
+        })
+      },
+      on<Data>(event: string, handler: (data: Data) => void) {
+        let handlers = listeners.get(event)
+        if (!handlers) {
+          handlers = new Set()
+          listeners.set(event, handlers)
+        }
+        handlers.add(handler)
+        return () => {
+          handlers!.delete(handler)
+        }
+      },
+    }
+  }
+}

--- a/opencode/tui-cli/src/core/types.ts
+++ b/opencode/tui-cli/src/core/types.ts
@@ -1,0 +1,81 @@
+export type WorkerLike = {
+  postMessage: (data: string) => void | null
+  onmessage: ((event: { data: string }) => void) | null
+  onerror?: ((event: unknown) => void) | null
+}
+
+export type Logger = {
+  error: (message: unknown, extra?: Record<string, unknown>) => void
+}
+
+export type Ui = {
+  error: (message: string) => void
+}
+
+export type EventSource = {
+  on: (handler: (event: unknown) => void) => () => void
+}
+
+export type TuiArgs = {
+  continue?: boolean
+  sessionID?: string
+  agent?: string
+  model?: string
+  prompt?: string
+}
+
+export type TuiAppInput = {
+  url: string
+  args: TuiArgs
+  directory?: string
+  fetch?: typeof fetch
+  events?: EventSource
+  onExit?: () => Promise<void>
+}
+
+export type TuiRunner = (input: TuiAppInput) => Promise<void>
+
+export type NetworkOptions = {
+  port: number
+  hostname: string
+  mdns: boolean
+  cors: string[]
+}
+
+export type ResolvedNetworkOptions = NetworkOptions
+
+export type TuiThreadArgs = NetworkOptions & {
+  project?: string
+  model?: string
+  continue?: boolean
+  session?: string
+  prompt?: string
+  agent?: string
+}
+
+export type AttachArgs = {
+  url: string
+  dir?: string
+  session?: string
+}
+
+export type WorkerRpc = {
+  fetch: (input: {
+    url: string
+    method: string
+    headers: Record<string, string>
+    body?: string
+  }) => Promise<{ status: number; headers: Record<string, string>; body: string }>
+  server: (input: ResolvedNetworkOptions) => Promise<{ url: string }>
+  checkUpgrade: (input: { directory: string }) => Promise<void>
+  reload: () => Promise<void>
+  shutdown: () => Promise<void>
+}
+
+export type RpcClient<TRpc> = {
+  call<Method extends keyof TRpc>(
+    method: Method,
+    input: Parameters<TRpc[Method]>[0],
+  ): Promise<ReturnType<TRpc[Method]>>
+  on<Data>(event: string, handler: (data: Data) => void): () => void
+}

--- a/opencode/tui-cli/src/core/ui.ts
+++ b/opencode/tui-cli/src/core/ui.ts
@@ -1,0 +1,5 @@
+export const UI = {
+  error: (message: string) => {
+    process.stderr.write(message + "\n")
+  },
+}

--- a/opencode/tui-cli/src/index.ts
+++ b/opencode/tui-cli/src/index.ts
@@ -1,0 +1,6 @@
+export { createAttachCommand } from "./commands/attach"
+export { createTuiThreadCommand } from "./commands/thread"
+export { cmd } from "./core/cmd"
+export { resolveNetworkOptions, withNetworkOptions } from "./core/network"
+export { Rpc } from "./core/rpc"
+export * from "./core/types"


### PR DESCRIPTION
Extract TUI CLI command-line components to isolate CLI entry points and their worker/RPC bridge from the full application.

---
<a href="https://cursor.com/background-agent?bcId=bc-4bb7262d-2cfc-4887-b8bd-530deb8c1397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4bb7262d-2cfc-4887-b8bd-530deb8c1397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a minimal, standalone TUI CLI layer under `opencode/tui-cli` that isolates CLI entry points and the worker/RPC bridge from the full app.
> 
> - Adds `createTuiThreadCommand` to launch the TUI: spawns worker (auto-selects `worker.js`/`worker.ts`), resolves network opts, conditionally starts server or uses in-worker `fetch`/event source, supports stdin-augmented prompts, session/model/agent args, graceful shutdown, and upgrade check
> - Adds `createAttachCommand` to connect to an existing server with optional working directory and session
> - Implements lightweight core modules: `cmd`, `rpc` (client/events), `network` (builder + resolver), `types`, `log`, `ui`, `iife`; re-exported via `index.ts`
> - Adds `README.md` documenting the extraction and intentionally omitted subsystems
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2df187e6c09155972c29592ce1412246cb9e188c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->